### PR TITLE
Update cached bank holidays as of 29/12/2022

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,10 @@ Alternatively, run ``python setup.py compilemessages sdist bdist_wheel upload`` 
 History
 -------
 
+0.12
+    Updated cached bank holidays file to include latest holidays published by GOV.UK.
+
+
 0.11
     Updated cached bank holidays file to include latest holidays published by GOV.UK.
     Added python 3.10 to testing matrix.

--- a/govuk_bank_holidays/__init__.py
+++ b/govuk_bank_holidays/__init__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 11)
+VERSION = (0, 12)
 __version__ = '.'.join(map(str, VERSION))
 __author__ = 'Ministry of Justice Digital & Technology'

--- a/govuk_bank_holidays/bank-holidays.json
+++ b/govuk_bank_holidays/bank-holidays.json
@@ -531,6 +531,12 @@
         "bunting": true
       },
       {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
         "title": "Boxing Day",
         "date": "2022-12-26",
         "notes": "",
@@ -567,6 +573,12 @@
         "bunting": true
       },
       {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
         "title": "Spring bank holiday",
         "date": "2023-05-29",
         "notes": "",
@@ -587,6 +599,102 @@
       {
         "title": "Boxing Day",
         "date": "2023-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2024-04-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2025-04-21",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
         "notes": "",
         "bunting": true
       }
@@ -1184,6 +1292,12 @@
         "bunting": true
       },
       {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
         "title": "St Andrew’s Day",
         "date": "2022-11-30",
         "notes": "",
@@ -1226,6 +1340,12 @@
         "bunting": true
       },
       {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
         "title": "Spring bank holiday",
         "date": "2023-05-29",
         "notes": "",
@@ -1252,6 +1372,114 @@
       {
         "title": "Boxing Day",
         "date": "2023-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2024-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2024-12-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2025-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-04",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2025-12-01",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
         "notes": "",
         "bunting": true
       }
@@ -1921,6 +2149,12 @@
         "bunting": true
       },
       {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
         "title": "Boxing Day",
         "date": "2022-12-26",
         "notes": "",
@@ -1963,6 +2197,12 @@
         "bunting": true
       },
       {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
         "title": "Spring bank holiday",
         "date": "2023-05-29",
         "notes": "",
@@ -1989,6 +2229,126 @@
       {
         "title": "Boxing Day",
         "date": "2023-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2024-03-18",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2024-04-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2024-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2025-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2025-04-21",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2025-07-14",
+        "notes": "Substitute day",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
         "notes": "",
         "bunting": true
       }


### PR DESCRIPTION
👋 

The cached bank holidays are a bit out of date. Any chance we can update them?

Do you have an internal process for keeping this file up-to-date and publishing new cached copies of the data/lib versions?